### PR TITLE
требование к php >=5.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": "^5.6",
+    "php": ">=5.6.0",
     "maximaster/tools.events": "^1.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.6.0",
+    "php": "^5.6 || ^7.0",
     "maximaster/tools.events": "^1.2"
   },
   "autoload": {


### PR DESCRIPTION
Основные модули битрикса корректно работают с версией php 7.0
Ограничение в composer.json не позволяли устанавливать Ваше решение на проекты, где используется php 7.0
Не проверял Ваше решение на версии php > 7.0, так как битрикс сам не работает на php начиная с 7.1