### PR TITLE
Изменил тип передаваемой переменной при инициализации кеша

### DIFF
--- a/src/AbstractFinder.php
+++ b/src/AbstractFinder.php
@@ -192,7 +192,7 @@ abstract class AbstractFinder
         $shards = $this->queryShards ? $this->queryShards : [];
         $path = $this->getFullCachePath($shards);
 
-        if ($cache->initCache(86400, null, $path)) {
+        if ($cache->initCache(86400, '', $path)) {
             $items = $cache->getVars();
         } else {
             $cache->startDataCache();


### PR DESCRIPTION
В новых версиях битрикса в классе Cache переменная $uniqueString имеет тип "строка"